### PR TITLE
Catch problematic warning during pnbd optimization, retry with bad observations removed

### DIFF
--- a/lifetimes/fitters/pareto_nbd_fitter.py
+++ b/lifetimes/fitters/pareto_nbd_fitter.py
@@ -560,7 +560,12 @@ class ParetoNBDFitter(BaseFitter):
                 inf_indices = np.where(np.isinf(likelihoods))
                 nan_indices = np.where(np.isnan(likelihoods))
                 bad_indices = np.concatenate((inf_indices[0], nan_indices[0]))
-                print(f"Number of bad indices: {bad_indices.size}")
+                if bad_indices.size > 10000:
+                    raise Exception(f"More than 10000 problematic rows removed. \
+                                     Either the param values ({last_params}) are wonky or there's scaling
+                                     issues with the data. Review f, r, t features to see if input is sensical")
+                else:
+                    print(f"Number of bad indices: {bad_indices.size}")
                 print(f"Problematic entries: {f[bad_indices]}, {r[bad_indices]}, {t[bad_indices]}")
 
                 f = np.delete(f, bad_indices)


### PR DESCRIPTION
While investigating convergence issues for the lifetimes pnbd, I found that when the following warning hits:
```
RuntimeWarning: invalid value encountered in subtract
  numpy.max(numpy.abs(fsim[0] - fsim[1:])) <= fatol):
```
it implies the likelihood is infinite (or in some cases nan) which causes the optimization to get stuck at the current parameter values.

This update catches the numpy warning as an actual RuntimeWarning, finds the individual entries that caused the likelihood to be infinite, and retries optimization with those entries removed.

I tested this out on the database export dates that caused brooks and golftown to produce the above warning, and with the update both sites converged successfully